### PR TITLE
Update Dockerfile to use pre-built conformance image

### DIFF
--- a/conformance-build/Dockerfile
+++ b/conformance-build/Dockerfile
@@ -1,19 +1,6 @@
 FROM gradle:8-jdk17 AS base
 
-FROM base AS conformance
-RUN mkdir /conformance
-WORKDIR /conformance
-RUN <<EOF
-    set -e
-    CONFORMANCE_VERSION="v1.0.4"
-    UNAME_OS=$(uname -s)
-    UNAME_ARCH=$(uname -m)
-    CONFORMANCE_URL="https://github.com/connectrpc/conformance/releases/download/${CONFORMANCE_VERSION}/connectconformance-${CONFORMANCE_VERSION}-${UNAME_OS}-${UNAME_ARCH}.tar.gz"
-    echo "Downloading conformance from ${CONFORMANCE_URL}"
-    curl -sSL "${CONFORMANCE_URL}" -o conformance.tgz
-    tar -xvzf conformance.tgz
-    chmod +x connectconformance
-EOF
+FROM ghcr.io/igor-vovk/connect-conformance-dockerimage:1.0.4-1 AS conformance
 
 FROM base AS build
 


### PR DESCRIPTION
Reuse conformance from cached docker image instead of downloading and unpacking conformance binary each time